### PR TITLE
Return to latest_stable_version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [16]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Te merge replaces node 14 with 16 for github actions workflow